### PR TITLE
Fix: Ensure 'to' address is included in ZND transfers via extension

### DIFF
--- a/src/components/ZondWeb3Wallet/DAppRequest/DAppRequestContent/DAppRequestWebsite/DAppRequestFeature/ZondSendTransaction/ZondSendTransactionForContent/ZondSendTransactionForContent.tsx
+++ b/src/components/ZondWeb3Wallet/DAppRequest/DAppRequestContent/DAppRequestWebsite/DAppRequestFeature/ZondSendTransaction/ZondSendTransactionForContent/ZondSendTransactionForContent.tsx
@@ -88,7 +88,7 @@ const ZondSendTransactionForContent = observer(
         let transactionObject: any = {
           from,
           ...(to && { to }),
-          ...(data && { data }),
+          data,
           gas,
           value,
           nonce: await zondInstance?.getTransactionCount(from),
@@ -97,7 +97,7 @@ const ZondSendTransactionForContent = observer(
           const { maxFeePerGas, maxPriorityFeePerGas } = await getGasFeeData();
           transactionObject.type = "0x2";
           transactionObject.maxPriorityFeePerGas = maxPriorityFeePerGas;
-          transactionObject.maxFeePerGas = `0x${BigInt(maxFeePerGas).toString(16)}`;
+          transactionObject.maxFeePerGas = `0x${maxFeePerGas.toString(16)}`;
         } else {
           transactionObject.gasPrice = gasPrice;
         }
@@ -158,7 +158,7 @@ const ZondSendTransactionForContent = observer(
           const { maxFeePerGas, maxPriorityFeePerGas } = await getGasFeeData();
           transactionObject.type = "0x2";
           transactionObject.maxPriorityFeePerGas = maxPriorityFeePerGas;
-          transactionObject.maxFeePerGas = `0x${BigInt(maxFeePerGas).toString(16)}`;
+          transactionObject.maxFeePerGas = `0x${maxFeePerGas.toString(16)}`;
         } else {
           transactionObject.gasPrice = gasPrice;
         }

--- a/src/components/ZondWeb3Wallet/DAppRequest/DAppRequestContent/DAppRequestWebsite/DAppRequestFeature/ZondSendTransaction/ZondSendTransactionForContent/ZondSendTransactionForContent.tsx
+++ b/src/components/ZondWeb3Wallet/DAppRequest/DAppRequestContent/DAppRequestWebsite/DAppRequestFeature/ZondSendTransaction/ZondSendTransactionForContent/ZondSendTransactionForContent.tsx
@@ -64,26 +64,31 @@ const ZondSendTransactionForContent = observer(
       if (isConnected) {
         const onPermissionCallBack = async (hasApproved: boolean) => {
           if (hasApproved) {
-            await deployContract();
+            if (transactionType === SEND_TRANSACTION_TYPES.ZND_TRANSFER) {
+              await sendZndTransfer();
+            } else {
+              await deployContractOrInteract();
+            }
           }
         };
         setOnPermissionCallBack(onPermissionCallBack);
       }
-    }, [isConnected]);
+    }, [isConnected, transactionType]);
 
     const copyData = () => {
       navigator.clipboard.writeText(data);
     };
 
-    const deployContract = async () => {
+    const deployContractOrInteract = async () => {
       const request = dAppRequestData?.params?.[0];
       const mnemonicPhrases = watch().mnemonicPhrases.trim();
       try {
-        const { from, data, gas, type, value } = request;
+        const { from, to, data, gas, type, value } = request;
         const gasPrice = await zondInstance?.getGasPrice();
         let transactionObject: any = {
           from,
-          data,
+          ...(to && { to }),
+          ...(data && { data }),
           gas,
           value,
           nonce: await zondInstance?.getTransactionCount(from),
@@ -92,7 +97,7 @@ const ZondSendTransactionForContent = observer(
           const { maxFeePerGas, maxPriorityFeePerGas } = await getGasFeeData();
           transactionObject.type = "0x2";
           transactionObject.maxPriorityFeePerGas = maxPriorityFeePerGas;
-          transactionObject.maxFeePerGas = `0x${maxFeePerGas.toString(16)}`;
+          transactionObject.maxFeePerGas = `0x${BigInt(maxFeePerGas).toString(16)}`;
         } else {
           transactionObject.gasPrice = gasPrice;
         }
@@ -112,7 +117,61 @@ const ZondSendTransactionForContent = observer(
         }
       } catch (error) {
         addToResponseData({ error });
-        console.error("Contract deployment failed:", error);
+        console.error(
+          transactionType === SEND_TRANSACTION_TYPES.CONTRACT_DEPLOYMENT
+            ? "Contract deployment failed:"
+            : "Contract interaction failed:",
+          error,
+        );
+      }
+    };
+
+    const sendZndTransfer = async () => {
+      const request = dAppRequestData?.params?.[0];
+      const mnemonicPhrases = watch().mnemonicPhrases.trim();
+      try {
+        const { from, to, gas, type, value } = request;
+
+        if (!to) {
+          throw new Error("Recipient address ('to') is missing for ZND transfer.");
+        }
+
+        const gasPrice = await zondInstance?.getGasPrice();
+        let transactionObject: any = {
+          from,
+          to,
+          gas,
+          value,
+          nonce: await zondInstance?.getTransactionCount(from),
+        };
+
+        if (type === "0x2") {
+          const { maxFeePerGas, maxPriorityFeePerGas } = await getGasFeeData();
+          transactionObject.type = "0x2";
+          transactionObject.maxPriorityFeePerGas = maxPriorityFeePerGas;
+          transactionObject.maxFeePerGas = `0x${BigInt(maxFeePerGas).toString(16)}`;
+        } else {
+          transactionObject.gasPrice = gasPrice;
+        }
+
+        const signedTransaction = await zondInstance?.accounts.signTransaction(
+          transactionObject,
+          getHexSeedFromMnemonic(mnemonicPhrases),
+        );
+
+        if (signedTransaction) {
+          const transactionReceipt = await zondInstance?.sendSignedTransaction(
+            signedTransaction?.rawTransaction,
+          );
+          addToResponseData({
+            transactionHash: transactionReceipt?.transactionHash,
+          });
+        } else {
+          throw new Error("ZND Transfer transaction could not be signed");
+        }
+      } catch (error) {
+        addToResponseData({ error });
+        console.error("ZND Transfer failed:", error);
       }
     };
 

--- a/src/components/ZondWeb3Wallet/DAppRequest/DAppRequestContent/DAppRequestWebsite/DAppRequestFeature/ZondSendTransaction/ZondSendTransactionForContent/ZondSendTransactionForContent.tsx
+++ b/src/components/ZondWeb3Wallet/DAppRequest/DAppRequestContent/DAppRequestWebsite/DAppRequestFeature/ZondSendTransaction/ZondSendTransactionForContent/ZondSendTransactionForContent.tsx
@@ -132,8 +132,17 @@ const ZondSendTransactionForContent = observer(
       try {
         const { from, to, gas, type, value } = request;
 
+        if (!from) {
+          throw new Error("Sender address ('from') is missing for ZND transfer.");
+        }
         if (!to) {
           throw new Error("Recipient address ('to') is missing for ZND transfer.");
+        }
+        if (!gas) {
+          throw new Error("Gas limit ('gas') is missing for ZND transfer.");
+        }
+        if (value === undefined || value === null) {
+          throw new Error("Transfer amount ('value') is missing for ZND transfer.");
         }
 
         const gasPrice = await zondInstance?.getGasPrice();


### PR DESCRIPTION
**Issue**:
When a connected dApp requested a simple ZND transfer (sending native currency from one address to another), the transaction was being signed and broadcast by the extension without the recipient (to) address. This occurred because the component responsible for handling transaction approvals (ZondSendTransactionForContent.tsx) was using a single signing function (deployContract) designed primarily for contract deployment/interaction, which incorrectly omitted the to field for native transfers. This resulted in successful but malformed transactions on-chain.

**Solution**:
This change refactors the transaction signing logic within ZondSendTransactionForContent.tsx to correctly handle different transaction types:
Introduced sendZndTransfer function: A new, dedicated function was added to specifically handle ZND transfer requests. This function constructs the transaction object correctly, ensuring the to address is included.
Refactored deployContract: The original function was renamed to deployContractOrInteract and modified to handle both contract deployment (no to, has data) and contract interaction (has to, has data) by conditionally including the relevant fields (to, data) in the transaction object.
Conditional Logic in Approval Callback: The useEffect hook that sets the onPermissionCallBack (triggered on user approval) was updated. It now checks the transactionType and calls the appropriate signing function (sendZndTransfer or deployContractOrInteract), ensuring the correct logic is applied based on the dApp's request.

**Result**:
This fix ensures that ZND transfers initiated via the extension now include the correct recipient address in the signed transaction, resolving the original bug. Contract deployments and interactions also continue to be handled correctly by the refactored logic.