### PR TITLE
fix(inpage): pass jsonRpcStreamName so dApp requests reach the wallet

### DIFF
--- a/src/scripts/inPageScript.ts
+++ b/src/scripts/inPageScript.ts
@@ -4,6 +4,7 @@ import log from "loglevel";
 import { v4 as uuid } from "uuid";
 import {
   QRL_POST_MESSAGE_STREAM,
+  QRL_WALLET_PROVIDER_NAME,
   QRL_WEB3_WALLET_PROVIDER_INFO,
 } from "./constants/streamConstants";
 
@@ -16,6 +17,17 @@ const initializeInPageScript = () => {
 
     initializeProvider({
       connectionStream: qrlStream,
+      // The inpage provider, content script, and service worker all
+      // multiplex over the same stream, and ObjectMultiplex routes by
+      // substream name. Without this, `initializeProvider` falls back to
+      // its library default ("zond-wallet-provider"), which no longer
+      // matches the QRL_WALLET_PROVIDER_NAME ("qrl-wallet-provider") that
+      // the content script and service worker register on their sides
+      // (since the ZOND→QRL rename in commit f51d120) — so every
+      // JSON-RPC request (incl. `qrl_requestAccounts`) is silently
+      // dropped at the mux layer and the dApp's `provider.request()`
+      // hangs forever.
+      jsonRpcStreamName: QRL_WALLET_PROVIDER_NAME,
       logger: log,
       providerInfo: {
         uuid: uuid(),


### PR DESCRIPTION
## Summary

Closes #13.

`initializeProvider` defaults `jsonRpcStreamName` to `"zond-wallet-provider"` inside `@theqrl/zond-wallet-provider@0.1.0` (the library still ships the pre-rebrand constant internally). The content script and service worker register their `ObjectMultiplex` substream as `QRL_WALLET_PROVIDER_NAME` (`"qrl-wallet-provider"`) on their sides, so every JSON-RPC request the dApp sent through `provider.request(...)` was silently dropped at the mux — including `qrl_requestAccounts`, which made the connect popup never appear and the dApp hang.

The bug entered in commit f51d120 (the ZOND→QRL rename). Before that, both sides happened to align on `"zond-wallet-provider"` by relying on the library default. After the rename only the constants on the wallet side moved to `"qrl-wallet-provider"` — the inpage script's call to `initializeProvider` still didn't pass `jsonRpcStreamName`, so it picked up the now-mismatched library default.

Reproduces on commit `607238b` (current `main`), independently confirmed by @alamistoneq-hub in #13 with the page-console signature `ObjectMultiplex - orphaned data for stream "zond-wallet-provider"`.

## Fix

Pass the QRL constant explicitly to `initializeProvider` in `src/scripts/inPageScript.ts`, matching what the content script + service worker register on their side. One-line source change. Added a comment at the call site explaining the failure mode so the next person who upgrades `@theqrl/zond-wallet-provider` doesn't fall into the same trap.

## Why source instead of @alamistoneq-hub's `sed` workaround

The `sed` patch on the built `inPageScript.js` works as a hot-fix but disappears on every `npm run build`. This change makes `npm run build` produce a correct bundle by default.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean — verified `Extension/src/scripts/inPageScript.js` now contains `jsonRpcStreamName:"qrl-wallet-provider"` at the `initializeProvider` call site
- [x] Manual: loaded unpacked `Extension/` in Chrome, visited `zondscan.com/dapp-example`, clicked the QRL Web3 Wallet row in the EIP-6963 picker — `qrl_requestAccounts` reaches the middleware and resolves with the connected account (previously hung indefinitely)
- [ ] Followup smoke-test of `personal_sign` end-to-end (separate sub-issue may exist around the connectivity-popup display state, will follow up if reproducible)
