### PR TITLE
fix(lockManager): read nested crypto.kdfparams in shouldUpgradeKeystoreParams

### DIFF
--- a/src/scripts/lockManager/keystoreParams.test.ts
+++ b/src/scripts/lockManager/keystoreParams.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import {
+  RECOMMENDED_KEYSTORE_KDF_PARAMS,
+  shouldUpgradeKeystoreParams,
+} from "./keystoreParams";
+
+/** A keystore in the REAL nested shape (kdf/kdfparams under `crypto`). */
+const nestedKeystore = (kdf: string, params: Record<string, number>) => ({
+  version: 1,
+  id: "3198bc9c-6672-5ab3-d995-4942343ae5b6",
+  address: "Qb60e8dd61c5d32be8058bb8eb970870f07233155",
+  crypto: {
+    ciphertext: "deadbeef",
+    cipherparams: { iv: "bfb43120ae00e9de110f8325" },
+    cipher: "aes-256-gcm",
+    kdf,
+    kdfparams: { ...params, salt: "aa".repeat(32) },
+  },
+});
+
+describe("shouldUpgradeKeystoreParams", () => {
+  it("flags a real nested keystore with weak params", () => {
+    expect(
+      shouldUpgradeKeystoreParams(
+        nestedKeystore("argon2id", { m: 4096, t: 2, p: 1, dklen: 32 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not flag a real nested keystore at the recommended params", () => {
+    expect(
+      shouldUpgradeKeystoreParams(
+        nestedKeystore("argon2id", { ...RECOMMENDED_KEYSTORE_KDF_PARAMS }),
+      ),
+    ).toBe(false);
+  });
+
+  it("flags a nested keystore with a non-argon2id kdf", () => {
+    expect(
+      shouldUpgradeKeystoreParams(
+        nestedKeystore("scrypt", { n: 8192, r: 8, p: 1, dklen: 32 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("flags weak t and dklen individually", () => {
+    expect(
+      shouldUpgradeKeystoreParams(
+        nestedKeystore("argon2id", { m: 262144, t: 2, p: 1, dklen: 32 }),
+      ),
+    ).toBe(true);
+    expect(
+      shouldUpgradeKeystoreParams(
+        nestedKeystore("argon2id", { m: 262144, t: 8, p: 1, dklen: 16 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("still evaluates a flat (non-nested) shape", () => {
+    expect(
+      shouldUpgradeKeystoreParams({
+        kdf: "argon2id",
+        kdfparams: { m: 4096, t: 2, p: 1, dklen: 32 },
+      }),
+    ).toBe(true);
+    expect(
+      shouldUpgradeKeystoreParams({
+        kdf: "argon2id",
+        kdfparams: { ...RECOMMENDED_KEYSTORE_KDF_PARAMS },
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for non-keystore inputs", () => {
+    expect(shouldUpgradeKeystoreParams(null)).toBe(false);
+    expect(shouldUpgradeKeystoreParams(undefined)).toBe(false);
+    expect(shouldUpgradeKeystoreParams("keystore")).toBe(false);
+    expect(shouldUpgradeKeystoreParams({})).toBe(false);
+  });
+});

--- a/src/scripts/lockManager/keystoreParams.ts
+++ b/src/scripts/lockManager/keystoreParams.ts
@@ -21,7 +21,14 @@ type KdfParamsLike = {
 
 export const shouldUpgradeKeystoreParams = (keystore: unknown): boolean => {
   if (!keystore || typeof keystore !== "object") return false;
-  const k = keystore as KdfParamsLike;
+  // Real keystores (the KeyStore type returned by encrypt()) nest
+  // kdf/kdfparams under `crypto`; tolerate a flat shape too so foreign
+  // inputs are still evaluated rather than skipped.
+  const outer = keystore as { crypto?: unknown };
+  const k: KdfParamsLike =
+    outer.crypto && typeof outer.crypto === "object"
+      ? (outer.crypto as KdfParamsLike)
+      : (keystore as KdfParamsLike);
   if (k.kdf && k.kdf !== "argon2id") {
     // Anything that is not argon2id (e.g. legacy scrypt) should be upgraded.
     return true;


### PR DESCRIPTION
## Summary

`shouldUpgradeKeystoreParams` reads `kdf` / `kdfparams` at the keystore top level, but real keystores (the `KeyStore` type returned by `encrypt()`) nest them under `crypto`. Every real keystore therefore sees `kdf` and `kdfparams` as `undefined`, so the function always returns `false` and the transparent "re-encrypt weaker keystores on the next unlock" upgrade path (added in the audit remediation) never actually fires.

## Fix

Read the nested `crypto` location, with a fallback to the flat shape so foreign/flat inputs are still evaluated rather than silently skipped.

## Tests

Adds `keystoreParams.test.ts` covering real nested keystores (weak params, recommended params, non-argon2id kdf, individually weak `t` / `dklen`), the flat-shape fallback, and non-keystore inputs.

## Validation

- `npm run lint`: clean
- `npm run build` (tsc + vite): passes
- `npm test`: passes (new suite + full suite)

One-file behavioural fix; no API or format change.
