### PR TITLE
perf(crypto): ~10x faster unlock via hash-wasm argon2id + worker fan-out

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@radix-ui/react-select": "2.2.6",
         "@theqrl/qrl-cryptography": "0.3.0",
         "eth-phishing-detect": "1.2.0",
+        "hash-wasm": "4.12.0",
         "i18next": "25.10.10",
         "qrcode.react": "4.2.0",
         "react-i18next": "16.6.6"
@@ -8244,6 +8245,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/hash-wasm": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hash-wasm/-/hash-wasm-4.12.0.tgz",
+      "integrity": "sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==",
+      "license": "MIT"
     },
     "node_modules/hash.js": {
       "version": "1.1.7",

--- a/package.json
+++ b/package.json
@@ -129,6 +129,7 @@
     "@radix-ui/react-select": "2.2.6",
     "@theqrl/qrl-cryptography": "0.3.0",
     "eth-phishing-detect": "1.2.0",
+    "hash-wasm": "4.12.0",
     "i18next": "25.10.10",
     "qrcode.react": "4.2.0",
     "react-i18next": "16.6.6"

--- a/src/crypto/keystoreCrypto.test.ts
+++ b/src/crypto/keystoreCrypto.test.ts
@@ -1,0 +1,210 @@
+// @vitest-environment node
+// (node, not jsdom: @theqrl/web3-validator rejects Uint8Arrays created in
+// the jsdom realm, so the upstream encrypt/decrypt calls only work here)
+
+/**
+ * Byte-compatibility suite for the hash-wasm-backed keystore crypto.
+ *
+ * The whole point of src/crypto/keystoreCrypto.ts is that it is a drop-in
+ * replacement for @theqrl/web3-qrl-accounts encrypt()/decrypt(): existing
+ * keystores (written via the pure-JS @noble/hashes argon2id) must decrypt,
+ * and keystores we write must decrypt with the upstream library. These
+ * tests pin that equivalence with small-but-valid KDF parameters so the
+ * suite stays fast (the production m=262144 would take seconds per case).
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  decrypt as upstreamDecrypt,
+  encrypt as upstreamEncrypt,
+} from "@theqrl/web3-qrl-accounts";
+import { argon2id as nobleArgon2id } from "@theqrl/qrl-cryptography/argon2id.js";
+import { argon2id as wasmArgon2id } from "hash-wasm";
+import {
+  decryptKeystore,
+  encryptKeystore,
+  validateKdfParams,
+} from "./keystoreCrypto";
+
+// Extended-seed vector from the @theqrl/web3-qrl-accounts docs.
+const SEED_HEX =
+  "0x010000cea755979937e2dc6137c0e51ba0d1eb2a44920cefffb1a860cf194ea7d23d694045fd2c8a72ec5aecf1e7e5bb591ff2";
+const PASSWORD = "correct horse battery staple";
+// Smallest parameters the shared kdf_policy bounds allow.
+const FAST_KDF = { m: 4096, t: 2, p: 1, dklen: 32 };
+const FIXED_SALT =
+  "210d0ec956787d865358ac45716e6dd42e68d48e346d795746509523aeb477dd";
+const FIXED_IV = "bfb43120ae00e9de110f8325";
+
+const SLOW_TEST_TIMEOUT = 30000;
+
+describe("keystoreCrypto", () => {
+  it(
+    "round-trips its own keystores",
+    async () => {
+      const keystore = await encryptKeystore(SEED_HEX, PASSWORD, FAST_KDF);
+      expect(keystore.version).toBe(1);
+      expect(keystore.crypto.kdf).toBe("argon2id");
+      expect(keystore.address).toMatch(/^Q[0-9a-f]{40}$/);
+
+      const { address, seed } = await decryptKeystore(keystore, PASSWORD);
+      expect(seed).toBe(SEED_HEX);
+      expect(address.toLowerCase()).toBe(keystore.address.toLowerCase());
+    },
+    SLOW_TEST_TIMEOUT,
+  );
+
+  it(
+    "decrypts keystores written by the upstream pure-JS implementation",
+    async () => {
+      const upstreamKeystore = await upstreamEncrypt(SEED_HEX, PASSWORD, {
+        salt: FIXED_SALT,
+        iv: FIXED_IV,
+        ...FAST_KDF,
+      });
+
+      const { seed } = await decryptKeystore(upstreamKeystore, PASSWORD);
+      expect(seed).toBe(SEED_HEX);
+    },
+    SLOW_TEST_TIMEOUT,
+  );
+
+  it(
+    "writes keystores the upstream implementation can decrypt",
+    async () => {
+      const keystore = await encryptKeystore(SEED_HEX, PASSWORD, FAST_KDF);
+
+      const account = await upstreamDecrypt(keystore, PASSWORD);
+      expect(account.seed).toBe(SEED_HEX);
+    },
+    SLOW_TEST_TIMEOUT,
+  );
+
+  it(
+    "produces a byte-identical crypto envelope for fixed salt/iv/params",
+    async () => {
+      const ours = await encryptKeystore(SEED_HEX, PASSWORD, {
+        salt: FIXED_SALT,
+        iv: FIXED_IV,
+        ...FAST_KDF,
+      });
+      const theirs = await upstreamEncrypt(SEED_HEX, PASSWORD, {
+        salt: FIXED_SALT,
+        iv: FIXED_IV,
+        ...FAST_KDF,
+      });
+
+      expect(ours.crypto).toEqual(theirs.crypto);
+      expect(ours.address).toBe(theirs.address);
+      expect(ours.version).toBe(theirs.version);
+    },
+    SLOW_TEST_TIMEOUT,
+  );
+
+  it(
+    "rejects a wrong password via the GCM auth tag",
+    async () => {
+      const keystore = await encryptKeystore(SEED_HEX, PASSWORD, FAST_KDF);
+      await expect(
+        decryptKeystore(keystore, "not the password"),
+      ).rejects.toThrow();
+    },
+    SLOW_TEST_TIMEOUT,
+  );
+
+  it("rejects out-of-bounds kdf parameters", () => {
+    expect(() =>
+      validateKdfParams({ m: 2048, t: 2, p: 1, dklen: 32 }),
+    ).toThrow();
+    expect(() =>
+      validateKdfParams({ m: 4096, t: 1, p: 1, dklen: 32 }),
+    ).toThrow();
+    expect(() =>
+      validateKdfParams({ m: 4096, t: 2, p: 0, dklen: 32 }),
+    ).toThrow();
+    expect(() =>
+      validateKdfParams({ m: 4096, t: 2, p: 1, dklen: 8 }),
+    ).toThrow();
+    expect(() =>
+      validateKdfParams({ m: 4096, t: 2, p: 1, dklen: 32 }),
+    ).not.toThrow();
+  });
+
+  it(
+    "hash-wasm and @noble argon2id stay byte-identical (dependency drift guard)",
+    async () => {
+      const encoder = new TextEncoder();
+      const vectors = [
+        { password: PASSWORD, salt: FIXED_SALT },
+        // Unicode password, NFC-normalised the way every caller does it.
+        { password: "pässwörd-café-🔑".normalize("NFC"), salt: FIXED_SALT },
+      ];
+      for (const vector of vectors) {
+        const passwordBytes = encoder.encode(vector.password);
+        const saltBytes = new Uint8Array(
+          vector.salt.match(/.{2}/g)?.map((b) => parseInt(b, 16)) ?? [],
+        );
+        const wasm = await wasmArgon2id({
+          password: passwordBytes,
+          salt: saltBytes,
+          iterations: FAST_KDF.t,
+          memorySize: FAST_KDF.m,
+          parallelism: FAST_KDF.p,
+          hashLength: FAST_KDF.dklen,
+          outputType: "binary",
+        });
+        const noble = await nobleArgon2id(
+          passwordBytes,
+          saltBytes,
+          FAST_KDF.t,
+          FAST_KDF.m,
+          FAST_KDF.p,
+          FAST_KDF.dklen,
+        );
+        expect(Buffer.from(wasm).toString("hex")).toBe(
+          Buffer.from(noble).toString("hex"),
+        );
+      }
+    },
+    SLOW_TEST_TIMEOUT,
+  );
+
+  it(
+    "encodes the password exactly like upstream for leading/trailing U+0000",
+    async () => {
+      // @theqrl/web3-qrl-accounts encrypt()/decrypt() turn the password into
+      // bytes via hexToBytes(utf8ToHex(password)); utf8ToHex trims one leading
+      // and one trailing NUL. A raw TextEncoder pass would not, deriving a
+      // different key, so a keystore written on one side would fail to decrypt
+      // on the other for a NUL-padded password.
+      const paddedPassword = `\u0000${PASSWORD}\u0000`;
+
+      // Upstream writes with the padded password; we must decrypt it.
+      const upstreamKeystore = await upstreamEncrypt(SEED_HEX, paddedPassword, {
+        salt: FIXED_SALT,
+        iv: FIXED_IV,
+        ...FAST_KDF,
+      });
+      const fromUpstream = await decryptKeystore(
+        upstreamKeystore,
+        paddedPassword,
+      );
+      expect(fromUpstream.seed).toBe(SEED_HEX);
+
+      // We write with the padded password; upstream must decrypt it, and so
+      // must the trimmed form of the same password (utf8ToHex makes them equal).
+      const ourKeystore = await encryptKeystore(
+        SEED_HEX,
+        paddedPassword,
+        FAST_KDF,
+      );
+      expect((await upstreamDecrypt(ourKeystore, paddedPassword)).seed).toBe(
+        SEED_HEX,
+      );
+      expect((await decryptKeystore(ourKeystore, PASSWORD)).seed).toBe(
+        SEED_HEX,
+      );
+    },
+    SLOW_TEST_TIMEOUT,
+  );
+});

--- a/src/crypto/keystoreCrypto.ts
+++ b/src/crypto/keystoreCrypto.ts
@@ -1,0 +1,258 @@
+/**
+ * Keystore encrypt/decrypt with the argon2id KDF executed via hash-wasm
+ * (WebAssembly) instead of the pure-JS @noble/hashes implementation that
+ * @theqrl/web3-qrl-accounts uses internally.
+ *
+ * At the production KDF parameters (m=262144 KiB, t=8, p=1) the pure-JS
+ * derivation takes ~20 s per keystore; the WASM one takes ~2 s and produces
+ * byte-identical output (pinned by the cross-implementation vectors in
+ * keystoreCrypto.test.ts). The keystore JSON format, parameters, and
+ * AES-256-GCM layer are unchanged from @theqrl/web3-qrl-accounts, so
+ * keystores written by either implementation stay mutually compatible.
+ *
+ * Format contract (mirrors account.js in @theqrl/web3-qrl-accounts):
+ * - version: 1, id: UUID v4, address: "Q" + 40 lowercase hex chars
+ * - crypto.ciphertext: hex (no 0x) of AES-256-GCM output incl. the 16-byte
+ *   auth tag; the tag is the sole integrity/wrong-password check (no MAC)
+ * - crypto.cipherparams.iv: hex (no 0x), exactly 12 bytes
+ * - crypto.kdfparams.salt: hex (no 0x); the password is turned into bytes
+ *   exactly as @theqrl/web3-qrl-accounts does it, via utf8ToHex (which trims
+ *   one leading and one trailing U+0000), so the derived key is byte-identical
+ *   for every password (callers NFC-normalise first, matching existing flows)
+ */
+
+import { argon2id as argon2idWasm } from "hash-wasm";
+import { argon2id as argon2idJs } from "@theqrl/qrl-cryptography/argon2id.js";
+import { parseAndValidateSeed, seedToAccount } from "@theqrl/web3-qrl-accounts";
+import { utf8ToHex } from "@theqrl/web3-utils";
+import type { Bytes, KeyStore } from "@theqrl/web3";
+import { RECOMMENDED_KEYSTORE_KDF_PARAMS } from "@/scripts/lockManager/keystoreParams";
+
+export type DecryptedKeystore = {
+  /** Checksummed Q-address, as returned by seedToAccount. */
+  address: string;
+  /** 0x-prefixed hex extended seed, as returned by seedToAccount. */
+  seed: string;
+};
+
+export type KeystoreKdfParams = {
+  m: number;
+  t: number;
+  p: number;
+  dklen: number;
+};
+
+export type EncryptKeystoreOptions = Partial<KeystoreKdfParams> & {
+  /** Fixed salt (32 bytes) for deterministic output in tests. */
+  salt?: Uint8Array | string;
+  /** Fixed IV (12 bytes) for deterministic output in tests. */
+  iv?: Uint8Array | string;
+};
+
+// Parameter bounds mirrored from @theqrl/web3-qrl-accounts kdf_policy.js so
+// both implementations accept and reject the same keystores.
+const KDF_PARAM_BOUNDS: Record<keyof KeystoreKdfParams, [number, number]> = {
+  m: [4096, 1048576],
+  t: [2, 50],
+  p: [1, 16],
+  dklen: [16, 64],
+};
+
+const hexToBytes = (hex: string): Uint8Array<ArrayBuffer> => {
+  const clean = hex.startsWith("0x") ? hex.slice(2) : hex;
+  if (clean.length % 2 !== 0 || /[^0-9a-fA-F]/.test(clean)) {
+    throw new Error("keystoreCrypto: invalid hex string");
+  }
+  const bytes = new Uint8Array(clean.length / 2);
+  for (let i = 0; i < bytes.length; i++) {
+    bytes[i] = parseInt(clean.slice(i * 2, i * 2 + 2), 16);
+  }
+  return bytes;
+};
+
+const bytesToHex = (bytes: Uint8Array): string =>
+  Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+
+const toBytes = (value: Uint8Array | string): Uint8Array<ArrayBuffer> =>
+  typeof value === "string" ? hexToBytes(value) : new Uint8Array(value);
+
+export function validateKdfParams(params: KeystoreKdfParams): void {
+  for (const key of Object.keys(KDF_PARAM_BOUNDS) as Array<
+    keyof KeystoreKdfParams
+  >) {
+    const value = params[key];
+    const [min, max] = KDF_PARAM_BOUNDS[key];
+    if (!Number.isInteger(value) || value < min || value > max) {
+      throw new Error(
+        `keystoreCrypto: kdf parameter ${key}=${String(value)} outside [${String(min)}, ${String(max)}]`,
+      );
+    }
+  }
+}
+
+/**
+ * Derive the AES key with argon2id. hash-wasm computes byte-identical
+ * output to the @noble/hashes implementation ~10x faster; if WASM is
+ * unavailable (CSP without 'wasm-unsafe-eval', or the ~m KiB linear-memory
+ * allocation fails under pressure) we fall back to the pure-JS
+ * implementation the keystores were originally written with.
+ */
+async function deriveArgon2idKey(
+  passwordBytes: Uint8Array,
+  saltBytes: Uint8Array,
+  params: KeystoreKdfParams,
+): Promise<Uint8Array> {
+  try {
+    return await argon2idWasm({
+      password: passwordBytes,
+      salt: saltBytes,
+      iterations: params.t,
+      memorySize: params.m,
+      parallelism: params.p,
+      hashLength: params.dklen,
+      outputType: "binary",
+    });
+  } catch (error) {
+    // Loud on purpose: if this fires on every unlock the CSP is missing
+    // 'wasm-unsafe-eval' or hash-wasm regressed, and unlocks are silently
+    // ~10x slower than they should be.
+    console.warn(
+      "keystoreCrypto: WASM argon2id unavailable, falling back to pure-JS",
+      error,
+    );
+    return argon2idJs(
+      passwordBytes,
+      saltBytes,
+      params.t,
+      params.m,
+      params.p,
+      params.dklen,
+    );
+  }
+}
+
+async function importAesKey(
+  keyBytes: Uint8Array,
+  usage: KeyUsage,
+): Promise<CryptoKey> {
+  if (keyBytes.length !== 32) {
+    throw new Error("keystoreCrypto: wrong AES key length");
+  }
+  return crypto.subtle.importKey(
+    "raw",
+    new Uint8Array(keyBytes),
+    { name: "AES-GCM", length: 256 },
+    false,
+    [usage],
+  );
+}
+
+const assertIvLength = (iv: Uint8Array): void => {
+  if (iv.length !== 12) {
+    throw new Error("keystoreCrypto: IV must be 12 bytes");
+  }
+};
+
+/**
+ * Decrypt a keystore. Throws on malformed keystores and on wrong password
+ * (the AES-GCM auth-tag check rejects, same as the upstream decrypt()).
+ */
+export async function decryptKeystore(
+  keystore: KeyStore,
+  password: string,
+): Promise<DecryptedKeystore> {
+  if (keystore.version !== 1) {
+    throw new Error("keystoreCrypto: unsupported keystore version");
+  }
+  if (keystore.crypto.cipher !== "aes-256-gcm") {
+    throw new Error("keystoreCrypto: unsupported cipher");
+  }
+  if (keystore.crypto.kdf !== "argon2id") {
+    throw new Error("keystoreCrypto: unsupported kdf");
+  }
+  const { kdfparams } = keystore.crypto;
+  validateKdfParams(kdfparams);
+
+  // Match @theqrl/web3-qrl-accounts encrypt()/decrypt() exactly: the password
+  // becomes bytes via hexToBytes(utf8ToHex(password)), not a raw TextEncoder
+  // pass, so passwords with leading/trailing U+0000 derive the same key here
+  // as in the upstream library.
+  const passwordBytes = hexToBytes(utf8ToHex(password));
+  const saltBytes = toBytes(kdfparams.salt);
+  const derivedKey = await deriveArgon2idKey(
+    passwordBytes,
+    saltBytes,
+    kdfparams,
+  );
+
+  const iv = hexToBytes(keystore.crypto.cipherparams.iv);
+  assertIvLength(iv);
+  const aesKey = await importAesKey(derivedKey, "decrypt");
+  const seedBuffer = await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv },
+    aesKey,
+    hexToBytes(keystore.crypto.ciphertext),
+  );
+
+  const account = seedToAccount(new Uint8Array(seedBuffer));
+  return { address: account.address, seed: account.seed };
+}
+
+/**
+ * Encrypt a seed into a keystore byte-compatible with the upstream
+ * encrypt(): identical crypto envelope for identical salt/iv/params.
+ */
+export async function encryptKeystore(
+  seed: Bytes,
+  password: string,
+  options?: EncryptKeystoreOptions,
+): Promise<KeyStore> {
+  if (!password) {
+    throw new Error("keystoreCrypto: refusing to encrypt without a password");
+  }
+  const seedBytes = parseAndValidateSeed(seed);
+
+  const salt = options?.salt
+    ? toBytes(options.salt)
+    : crypto.getRandomValues(new Uint8Array(32));
+  const iv = options?.iv
+    ? toBytes(options.iv)
+    : crypto.getRandomValues(new Uint8Array(12));
+  assertIvLength(iv);
+
+  const kdf: KeystoreKdfParams = {
+    m: options?.m ?? RECOMMENDED_KEYSTORE_KDF_PARAMS.m,
+    t: options?.t ?? RECOMMENDED_KEYSTORE_KDF_PARAMS.t,
+    p: options?.p ?? RECOMMENDED_KEYSTORE_KDF_PARAMS.p,
+    dklen: options?.dklen ?? RECOMMENDED_KEYSTORE_KDF_PARAMS.dklen,
+  };
+  validateKdfParams(kdf);
+
+  // Match @theqrl/web3-qrl-accounts encrypt()/decrypt() exactly: the password
+  // becomes bytes via hexToBytes(utf8ToHex(password)), not a raw TextEncoder
+  // pass, so passwords with leading/trailing U+0000 derive the same key here
+  // as in the upstream library.
+  const passwordBytes = hexToBytes(utf8ToHex(password));
+  const derivedKey = await deriveArgon2idKey(passwordBytes, salt, kdf);
+
+  const aesKey = await importAesKey(derivedKey, "encrypt");
+  const cipherBuffer = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    aesKey,
+    new Uint8Array(seedBytes),
+  );
+
+  const account = seedToAccount(new Uint8Array(seedBytes));
+  return {
+    version: 1,
+    id: crypto.randomUUID(),
+    address: `Q${account.address.slice(1).toLowerCase()}`,
+    crypto: {
+      ciphertext: bytesToHex(new Uint8Array(cipherBuffer)),
+      cipherparams: { iv: bytesToHex(iv) },
+      cipher: "aes-256-gcm",
+      kdf: "argon2id",
+      kdfparams: { ...kdf, salt: bytesToHex(salt) },
+    },
+  };
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,6 +3,9 @@
   "minimum_chrome_version": "114",
   "name": "QRL Web3 Wallet",
   "description": "A web3 wallet that run on the QRL blockchain.",
+  "content_security_policy": {
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
+  },
   "icons": {
     "16": "icons/qrl/16.png",
     "24": "icons/qrl/24.png",

--- a/src/scripts/lockManager/lockManager.integration.test.ts
+++ b/src/scripts/lockManager/lockManager.integration.test.ts
@@ -92,9 +92,8 @@ vi.mock("webextension-polyfill", () => ({
 }));
 
 vi.mock("@theqrl/web3", () => ({ Bytes: class {} }));
-vi.mock("@theqrl/web3-qrl-accounts", () => ({
-  decrypt: vi.fn(),
-  encrypt: vi.fn(),
+vi.mock("@/crypto/keystoreCrypto", () => ({
+  encryptKeystore: vi.fn(),
 }));
 vi.mock("@/functions/getMnemonicFromHexSeed", () => ({
   getMnemonicFromHexSeed: vi.fn(() => "mocked mnemonic"),

--- a/src/scripts/lockManager/lockManager.test.ts
+++ b/src/scripts/lockManager/lockManager.test.ts
@@ -61,9 +61,8 @@ vi.mock("webextension-polyfill", () => ({
 }));
 
 vi.mock("@theqrl/web3", () => ({ Bytes: class {} }));
-vi.mock("@theqrl/web3-qrl-accounts", () => ({
-  decrypt: vi.fn(),
-  encrypt: vi.fn(),
+vi.mock("@/crypto/keystoreCrypto", () => ({
+  encryptKeystore: vi.fn(),
 }));
 vi.mock("@/functions/getMnemonicFromHexSeed", () => ({
   getMnemonicFromHexSeed: vi.fn(() => "mocked mnemonic"),

--- a/src/scripts/lockManager/lockManager.ts
+++ b/src/scripts/lockManager/lockManager.ts
@@ -1,6 +1,6 @@
 import StorageUtil, { LockState } from "@/utilities/storageUtil";
 import { Bytes } from "@theqrl/web3";
-import { decrypt, encrypt } from "@theqrl/web3-qrl-accounts";
+import { encryptKeystore } from "@/crypto/keystoreCrypto";
 import { getMnemonicFromHexSeed } from "@/functions/getMnemonicFromHexSeed";
 import browser from "webextension-polyfill";
 
@@ -36,7 +36,6 @@ export const LOCK_MANAGER_MESSAGES = {
   IS_LOCKED: "LOCK_MANAGER_IS_LOCKED",
   ENCRYPT_ACCOUNT: "ENCRYPT_ACCOUNT",
   LOCK: "LOCK_MANAGER_LOCK",
-  UNLOCK: "LOCK_MANAGER_UNLOCK",
   LOCK_MANAGER_KEEP_LIVE: "LOCK_MANAGER_KEEP_LIVE",
   GET_DECRYPTED_KEYS: "GET_DECRYPTED_KEYS",
   GET_WALLET_PASSWORD: "GET_WALLET_PASSWORD",
@@ -48,10 +47,13 @@ export const LOCK_MANAGER_MESSAGES = {
 /**
  * The lock manager, which is part of the extension service worker handles lock related data and functions.
  *
- * IMPORTANT: CPU-heavy cryptographic operations (decrypt / encrypt via scrypt)
- * are performed in the popup, NOT in the service worker.  The popup sends the
+ * IMPORTANT: CPU-heavy keystore decryption (argon2id) is performed in the
+ * popup's worker pool, NOT in the service worker.  The popup sends the
  * resulting keys to the SW via the SET_DECRYPTED_KEYS message so that the SW
  * only stores them in memory.  This avoids Chrome killing the SW mid-decrypt.
+ * The one KDF the SW does run itself is encryptAccount (new account
+ * create/import); it goes through the hash-wasm-backed encryptKeystore, ~2 s
+ * instead of the ~20 s the pure-JS KDF took.
  */
 class LockManager {
   private static decryptedKeys?: DecryptedKeyType[];
@@ -151,47 +153,6 @@ class LockManager {
     return false;
   }
 
-  /**
-   * Decrypt all keystores with the given password.
-   * Called via a dedicated port connection so there is no message-channel
-   * timeout — the port stays open as long as needed.
-   * Returns true on success, false on wrong password or empty keystores.
-   */
-  static async unlock(password: string): Promise<boolean> {
-    try {
-      // Normalise to NFC so the same visual password yields the same bytes
-      // regardless of the platform / IME the user typed it on.
-      const normalisedPassword = password.normalize("NFC");
-      const keyStores = await StorageUtil.getKeystores();
-      if (!keyStores.length) return false;
-      const decryptedKeys: DecryptedKeyType[] = [];
-      for (const keyStore of keyStores) {
-        // Yield the event loop between decryptions so Chrome
-        // doesn't consider the service worker unresponsive.
-        await new Promise((r) => setTimeout(r, 0));
-        const { address, seed } = await decrypt(keyStore, normalisedPassword);
-        decryptedKeys.push({
-          address,
-          seed,
-          mnemonicPhrases: getMnemonicFromHexSeed(seed),
-        });
-      }
-      this.walletPassword = normalisedPassword;
-      this.setDecryptedKeys(
-        Array.from(
-          new Map(
-            decryptedKeys.map((item) => [item.address.toLowerCase(), item]),
-          ).values(),
-        ),
-      );
-      return true;
-    } catch {
-      this.clearDecryptedKeys();
-      this.walletPassword = undefined;
-      return false;
-    }
-  }
-
   static async isLocked() {
     const keyStores = await StorageUtil.getKeystores();
     const accounts = await StorageUtil.getAllAccounts();
@@ -242,7 +203,7 @@ class LockManager {
     const { password: rawPassword, seed } = accountData;
     const password = rawPassword.normalize("NFC");
     const keystores = await StorageUtil.getKeystores();
-    const encryptedKeyStore = await encrypt(seed, password);
+    const encryptedKeyStore = await encryptKeystore(seed, password);
     const updatedKeyStores = [...keystores, encryptedKeyStore];
     await StorageUtil.setKeystores(
       Array.from(

--- a/src/scripts/workers/changePasswordWorker.ts
+++ b/src/scripts/workers/changePasswordWorker.ts
@@ -1,14 +1,20 @@
 /**
- * Web Worker that re-encrypts all keystores with a new password.
+ * Web Worker that re-encrypts keystores with a new password.
  *
- * 1. Decrypts each keystore with the old password (CPU-heavy scrypt).
+ * 1. Decrypts each keystore with the old password (CPU-heavy argon2id,
+ *    executed via hash-wasm, see src/crypto/keystoreCrypto.ts).
  * 2. Re-encrypts each seed with the new password.
- * 3. Returns the new keystores and decrypted key metadata.
+ * 3. Returns the new keystores and decrypted key metadata, aligned with the
+ *    request's keystore order.
  *
- * Runs in a dedicated thread so the popup UI stays responsive.
+ * Runs in a dedicated thread so the popup UI stays responsive; the popup
+ * fans keystores out over several instances via keystoreWorkerPool.
  */
 
-import { decrypt, encrypt } from "@theqrl/web3-qrl-accounts";
+import {
+  decryptKeystore,
+  encryptKeystore,
+} from "@/crypto/keystoreCrypto";
 import { getMnemonicFromHexSeed } from "@/functions/getMnemonicFromHexSeed";
 import type { KeyStore } from "@theqrl/web3";
 
@@ -26,7 +32,19 @@ export type DecryptedKey = {
 
 export type ChangePasswordWorkerResponse =
   | { success: true; newKeystores: KeyStore[]; newKeys: DecryptedKey[] }
-  | { success: false };
+  | {
+      success: false;
+      /**
+       * true when the AES-GCM auth tag rejected (wrong old password); false
+       * for infrastructure failures so the popup can retry sequentially
+       * instead of blaming the password.
+       */
+      wrongPassword: boolean;
+    };
+
+/** WebCrypto surfaces a failed GCM auth-tag check as an OperationError. */
+const isWrongPasswordError = (error: unknown): boolean =>
+  error instanceof DOMException && error.name === "OperationError";
 
 self.onmessage = async (
   event: MessageEvent<ChangePasswordWorkerRequest>,
@@ -41,8 +59,8 @@ self.onmessage = async (
     const newKeys: DecryptedKey[] = [];
 
     for (const keyStore of keystores) {
-      const { address, seed } = await decrypt(keyStore, normalisedOld);
-      const reEncrypted = await encrypt(seed, normalisedNew);
+      const { address, seed } = await decryptKeystore(keyStore, normalisedOld);
+      const reEncrypted = await encryptKeystore(seed, normalisedNew);
       newKeystores.push(reEncrypted);
       newKeys.push({
         address,
@@ -56,8 +74,10 @@ self.onmessage = async (
       newKeystores,
       newKeys,
     } satisfies ChangePasswordWorkerResponse);
-  } catch {
-    // decrypt() throws when the old password is wrong
-    self.postMessage({ success: false } satisfies ChangePasswordWorkerResponse);
+  } catch (error) {
+    self.postMessage({
+      success: false,
+      wrongPassword: isWrongPasswordError(error),
+    } satisfies ChangePasswordWorkerResponse);
   }
 };

--- a/src/scripts/workers/keystoreWorkerPool.test.ts
+++ b/src/scripts/workers/keystoreWorkerPool.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  kdfWorkerCount,
+  runWorkerJob,
+  splitIntoChunks,
+} from "./keystoreWorkerPool";
+
+describe("splitIntoChunks", () => {
+  it("splits contiguously and preserves order on concatenation", () => {
+    const items = [1, 2, 3, 4, 5];
+    const chunks = splitIntoChunks(items, 3);
+    expect(chunks).toEqual([[1, 2], [3, 4], [5]]);
+    expect(chunks.flat()).toEqual(items);
+  });
+
+  it("never produces empty chunks when chunkCount exceeds item count", () => {
+    expect(splitIntoChunks([1, 2], 5)).toEqual([[1], [2]]);
+  });
+
+  it("returns a single chunk for chunkCount 1", () => {
+    expect(splitIntoChunks([1, 2, 3], 1)).toEqual([[1, 2, 3]]);
+  });
+
+  it("returns no chunks for an empty list", () => {
+    expect(splitIntoChunks([], 3)).toEqual([]);
+  });
+});
+
+describe("kdfWorkerCount", () => {
+  const setCores = (cores: number | undefined) => {
+    Object.defineProperty(navigator, "hardwareConcurrency", {
+      value: cores,
+      configurable: true,
+    });
+  };
+
+  afterEach(() => setCores(undefined));
+
+  it("caps at the memory ceiling regardless of cores", () => {
+    setCores(16);
+    expect(kdfWorkerCount(10)).toBe(3);
+  });
+
+  it("never exceeds the item count", () => {
+    setCores(8);
+    expect(kdfWorkerCount(1)).toBe(1);
+    expect(kdfWorkerCount(2)).toBe(2);
+  });
+
+  it("caps at the core count on small machines", () => {
+    setCores(2);
+    expect(kdfWorkerCount(10)).toBe(2);
+  });
+
+  it("returns at least one worker when core detection is unavailable", () => {
+    setCores(undefined);
+    expect(kdfWorkerCount(5)).toBe(2);
+    expect(kdfWorkerCount(0)).toBe(1);
+  });
+});
+
+describe("runWorkerJob", () => {
+  type Req = { input: string };
+  type Res = { success: boolean; echo?: string };
+
+  class FakeWorker {
+    onmessage: ((event: MessageEvent<Res>) => void) | null = null;
+    onerror: ((event: ErrorEvent) => void) | null = null;
+    terminated = false;
+    constructor(private readonly behavior: "reply" | "error") {}
+    postMessage(request: Req) {
+      queueMicrotask(() => {
+        if (this.behavior === "reply") {
+          this.onmessage?.({
+            data: { success: true, echo: request.input },
+          } as MessageEvent<Res>);
+        } else {
+          this.onerror?.(new Event("error") as ErrorEvent);
+        }
+      });
+    }
+    terminate() {
+      this.terminated = true;
+    }
+  }
+
+  it("resolves with the worker response and terminates the worker", async () => {
+    const worker = new FakeWorker("reply");
+    const result = await runWorkerJob<Req, Res>(
+      () => worker as unknown as Worker,
+      { input: "hello" },
+      { success: false },
+    );
+    expect(result).toEqual({ success: true, echo: "hello" });
+    expect(worker.terminated).toBe(true);
+  });
+
+  it("resolves with the failure value on worker error", async () => {
+    const worker = new FakeWorker("error");
+    const result = await runWorkerJob<Req, Res>(
+      () => worker as unknown as Worker,
+      { input: "boom" },
+      { success: false },
+    );
+    expect(result).toEqual({ success: false });
+    expect(worker.terminated).toBe(true);
+  });
+
+  it("spawns a fresh worker per job", async () => {
+    const factory = vi.fn(() => new FakeWorker("reply") as unknown as Worker);
+    await runWorkerJob<Req, Res>(factory, { input: "a" }, { success: false });
+    await runWorkerJob<Req, Res>(factory, { input: "b" }, { success: false });
+    expect(factory).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/scripts/workers/keystoreWorkerPool.ts
+++ b/src/scripts/workers/keystoreWorkerPool.ts
@@ -1,0 +1,61 @@
+/**
+ * Helpers for fanning keystore KDF work out over multiple Web Workers so N
+ * keystores decrypt concurrently instead of back to back in one thread.
+ *
+ * Concurrency is capped independently of core count because every in-flight
+ * argon2id derivation at the production parameters (m=262144 KiB) pins
+ * ~256 MiB of memory for its duration.
+ */
+
+const MAX_KDF_WORKERS = 3;
+
+export function kdfWorkerCount(itemCount: number): number {
+  const cores =
+    typeof navigator !== "undefined" && navigator.hardwareConcurrency
+      ? navigator.hardwareConcurrency
+      : 2;
+  return Math.max(1, Math.min(itemCount, cores, MAX_KDF_WORKERS));
+}
+
+/**
+ * Split items into at most chunkCount contiguous chunks. Contiguous so that
+ * concatenating per-chunk results in chunk order reproduces the original
+ * item order.
+ */
+export function splitIntoChunks<T>(items: T[], chunkCount: number): T[][] {
+  const chunks: T[][] = [];
+  const base = Math.floor(items.length / chunkCount);
+  const extra = items.length % chunkCount;
+  let offset = 0;
+  for (let i = 0; i < chunkCount; i++) {
+    const size = base + (i < extra ? 1 : 0);
+    if (size === 0) continue;
+    chunks.push(items.slice(offset, offset + size));
+    offset += size;
+  }
+  return chunks;
+}
+
+/**
+ * Post one request to a fresh worker, resolve with its single response, and
+ * terminate the worker either way. Worker-level errors resolve with the
+ * caller-supplied failure value so Promise.all over chunks never rejects.
+ */
+export function runWorkerJob<TRequest, TResponse>(
+  createWorker: () => Worker,
+  request: TRequest,
+  failureResponse: TResponse,
+): Promise<TResponse> {
+  return new Promise((resolve) => {
+    const worker = createWorker();
+    worker.onmessage = (event: MessageEvent<TResponse>) => {
+      worker.terminate();
+      resolve(event.data);
+    };
+    worker.onerror = () => {
+      worker.terminate();
+      resolve(failureResponse);
+    };
+    worker.postMessage(request);
+  });
+}

--- a/src/scripts/workers/unlockWorker.ts
+++ b/src/scripts/workers/unlockWorker.ts
@@ -1,17 +1,19 @@
 /**
- * Web Worker that performs the CPU-heavy keystore decryption (scrypt / argon2id).
+ * Web Worker that performs the CPU-heavy keystore decryption (argon2id).
  *
  * Running in a dedicated worker thread keeps the popup UI fully responsive
  * while the decryption is in progress AND avoids Chrome's MV3 service-worker
  * lifecycle issues (Chrome can't kill a worker that runs inside the popup).
+ *
+ * The popup fans the keystores out over several of these workers via
+ * keystoreWorkerPool, so each instance receives a contiguous chunk of the
+ * full keystore list and returns results aligned with its chunk order.
+ * The KDF itself runs via hash-wasm (see src/crypto/keystoreCrypto.ts).
  */
 
-import { decrypt, encrypt } from "@theqrl/web3-qrl-accounts";
+import { decryptKeystore, encryptKeystore } from "@/crypto/keystoreCrypto";
 import { getMnemonicFromHexSeed } from "@/functions/getMnemonicFromHexSeed";
-import {
-  RECOMMENDED_KEYSTORE_KDF_PARAMS,
-  shouldUpgradeKeystoreParams,
-} from "@/scripts/lockManager/keystoreParams";
+import { shouldUpgradeKeystoreParams } from "@/scripts/lockManager/keystoreParams";
 import type { KeyStore } from "@theqrl/web3";
 
 export type UnlockWorkerRequest = {
@@ -28,13 +30,30 @@ export type DecryptedKey = {
 export type UnlockWorkerResponse =
   | {
       success: true;
+      /** Aligned with the request's keystore order. */
       keys: DecryptedKey[];
-      // Populated when one or more keystores were re-encrypted with stronger
-      // KDF parameters. The popup-side persists these in place of the old
-      // keystores so the user does not need to take any explicit action.
-      upgradedKeystores?: KeyStore[];
+      /**
+       * Aligned with the request's keystore order; a non-null entry is that
+       * keystore re-encrypted with stronger KDF parameters. The popup-side
+       * persists these in place of the old keystores so the user does not
+       * need to take any explicit action.
+       */
+      upgraded: (KeyStore | null)[];
     }
-  | { success: false };
+  | {
+      success: false;
+      /**
+       * true when the AES-GCM auth tag rejected (wrong password); false for
+       * infrastructure failures (e.g. the WASM memory allocation failed), so
+       * the popup can retry or surface a distinct error instead of telling
+       * the user their correct password is wrong.
+       */
+      wrongPassword: boolean;
+    };
+
+/** WebCrypto surfaces a failed GCM auth-tag check as an OperationError. */
+const isWrongPasswordError = (error: unknown): boolean =>
+  error instanceof DOMException && error.name === "OperationError";
 
 self.onmessage = async (event: MessageEvent<UnlockWorkerRequest>) => {
   const { keystores, password } = event.data;
@@ -43,34 +62,32 @@ self.onmessage = async (event: MessageEvent<UnlockWorkerRequest>) => {
   const normalisedPassword = password.normalize("NFC");
   try {
     const keys: DecryptedKey[] = [];
-    let upgradedKeystores: KeyStore[] | undefined;
+    const upgraded: (KeyStore | null)[] = [];
     for (const keyStore of keystores) {
-      const { address, seed } = await decrypt(keyStore, normalisedPassword);
+      const { address, seed } = await decryptKeystore(
+        keyStore,
+        normalisedPassword,
+      );
       keys.push({
         address,
         seed,
         mnemonicPhrases: getMnemonicFromHexSeed(seed),
       });
-      if (shouldUpgradeKeystoreParams(keyStore)) {
-        if (!upgradedKeystores) {
-          upgradedKeystores = [...keystores];
-        }
-        const reEncrypted = await encrypt(seed, normalisedPassword);
-        const idx = upgradedKeystores.findIndex(
-          (k) => k.address?.toLowerCase() === keyStore.address?.toLowerCase(),
-        );
-        if (idx >= 0) upgradedKeystores[idx] = reEncrypted;
-      }
+      upgraded.push(
+        shouldUpgradeKeystoreParams(keyStore)
+          ? await encryptKeystore(seed, normalisedPassword)
+          : null,
+      );
     }
-    // Reference the constant so tree-shaking does not drop the import.
-    void RECOMMENDED_KEYSTORE_KDF_PARAMS;
     self.postMessage({
       success: true,
       keys,
-      upgradedKeystores,
+      upgraded,
     } satisfies UnlockWorkerResponse);
-  } catch {
-    // decrypt() throws when the password is wrong
-    self.postMessage({ success: false } satisfies UnlockWorkerResponse);
+  } catch (error) {
+    self.postMessage({
+      success: false,
+      wrongPassword: isWrongPasswordError(error),
+    } satisfies UnlockWorkerResponse);
   }
 };

--- a/src/stores/lockStore.test.ts
+++ b/src/stores/lockStore.test.ts
@@ -207,3 +207,152 @@ describe("LockStore – readLockState timestamp check", () => {
     });
   });
 });
+
+describe("LockStore – unlock worker fan-out", () => {
+  type WorkerResponse = Record<string, unknown>;
+  type WorkerBehavior = (request: {
+    keystores: unknown[];
+    password: string;
+  }) => WorkerResponse | "error";
+
+  /**
+   * Stub for the global Worker: each spawned instance consumes the next
+   * scripted behavior, mirroring the pool's fresh-worker-per-chunk model.
+   */
+  let behaviors: WorkerBehavior[] = [];
+  let spawned = 0;
+
+  class StubWorker {
+    onmessage: ((event: { data: WorkerResponse }) => void) | null = null;
+    onerror: ((event: unknown) => void) | null = null;
+    private readonly behavior: WorkerBehavior;
+    constructor() {
+      const next = behaviors[Math.min(spawned, behaviors.length - 1)];
+      this.behavior = next;
+      spawned += 1;
+    }
+    postMessage(request: { keystores: unknown[]; password: string }) {
+      queueMicrotask(() => {
+        const result = this.behavior(request);
+        if (result === "error") {
+          this.onerror?.(new Event("error"));
+        } else {
+          this.onmessage?.({ data: result });
+        }
+      });
+    }
+    terminate() {}
+  }
+
+  const KEYSTORE_A = { address: "qaaa", crypto: {} };
+  const KEYSTORE_B = { address: "qbbb", crypto: {} };
+  const KEY_A = { address: "Qaaa", mnemonicPhrases: "mnemonic a" };
+  const KEY_B = { address: "Qbbb", mnemonicPhrases: "mnemonic b" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearStore(localStore);
+    behaviors = [];
+    spawned = 0;
+    vi.stubGlobal("Worker", StubWorker);
+    Object.defineProperty(navigator, "hardwareConcurrency", {
+      value: 4,
+      configurable: true,
+    });
+    localStore["KEYSTORES"] = JSON.stringify([KEYSTORE_A, KEYSTORE_B]);
+  });
+
+  async function createLockStore() {
+    mockSendMessage.mockResolvedValue({ isLocked: false, hasPasswordSet: true });
+    const module = await import("./lockStore");
+    const store = new module.default();
+    await new Promise((r) => setTimeout(r, 300));
+    return store;
+  }
+
+  it("fans keystores out over one worker per chunk and merges the keys in order", async () => {
+    const store = await createLockStore();
+    behaviors = [
+      () => ({ success: true, keys: [KEY_A], upgraded: [null] }),
+      () => ({ success: true, keys: [KEY_B], upgraded: [null] }),
+    ];
+
+    const unlocked = await store.unlock("pw");
+
+    expect(unlocked).toBe(true);
+    expect(spawned).toBe(2);
+    const setKeysCall: any = mockSendMessage.mock.calls.find(
+      (call: any) => call[0]?.name === "SET_DECRYPTED_KEYS",
+    );
+    expect(setKeysCall?.[0]?.data?.keys).toEqual([KEY_A, KEY_B]);
+  });
+
+  it("returns false without retrying when a worker reports a wrong password", async () => {
+    const store = await createLockStore();
+    behaviors = [
+      () => ({ success: true, keys: [KEY_A], upgraded: [null] }),
+      () => ({ success: false, wrongPassword: true }),
+    ];
+
+    const unlocked = await store.unlock("bad-pw");
+
+    expect(unlocked).toBe(false);
+    expect(spawned).toBe(2);
+    const setKeysCalls = mockSendMessage.mock.calls.filter(
+      (call: any) => call[0]?.name === "SET_DECRYPTED_KEYS",
+    );
+    expect(setKeysCalls).toHaveLength(0);
+  });
+
+  it("retries sequentially after an infrastructure failure and succeeds", async () => {
+    const store = await createLockStore();
+    behaviors = [
+      () => ({ success: true, keys: [KEY_A], upgraded: [null] }),
+      () => "error",
+      // Sequential retry gets ALL keystores in one request.
+      (req) => ({
+        success: true,
+        keys: req.keystores.length === 2 ? [KEY_A, KEY_B] : [],
+        upgraded: [null, null],
+      }),
+    ];
+
+    const unlocked = await store.unlock("pw");
+
+    expect(unlocked).toBe(true);
+    expect(spawned).toBe(3);
+    const setKeysCall: any = mockSendMessage.mock.calls.find(
+      (call: any) => call[0]?.name === "SET_DECRYPTED_KEYS",
+    );
+    expect(setKeysCall?.[0]?.data?.keys).toEqual([KEY_A, KEY_B]);
+  });
+
+  it("throws a distinct error when the sequential retry also fails on infrastructure", async () => {
+    const store = await createLockStore();
+    behaviors = [
+      () => "error",
+      () => ({ success: true, keys: [KEY_B], upgraded: [null] }),
+      () => ({ success: false, wrongPassword: false }),
+    ];
+
+    await expect(store.unlock("pw")).rejects.toThrow(/free memory/);
+    expect(spawned).toBe(3);
+  });
+
+  it("persists upgraded keystores index-aligned with the original list", async () => {
+    const store = await createLockStore();
+    const upgradedB = { address: "qbbb", crypto: { upgraded: true } };
+    behaviors = [
+      () => ({ success: true, keys: [KEY_A], upgraded: [null] }),
+      () => ({ success: true, keys: [KEY_B], upgraded: [upgradedB] }),
+    ];
+
+    const unlocked = await store.unlock("pw");
+
+    expect(unlocked).toBe(true);
+    expect(JSON.parse(localStore["KEYSTORES"])).toEqual([
+      KEYSTORE_A,
+      upgradedB,
+    ]);
+  });
+});

--- a/src/stores/lockStore.ts
+++ b/src/stores/lockStore.ts
@@ -4,10 +4,20 @@ import {
   LOCK_MANAGER_MESSAGES,
 } from "@/scripts/lockManager/lockManager";
 import type {
+  ChangePasswordWorkerRequest,
   ChangePasswordWorkerResponse,
 } from "@/scripts/workers/changePasswordWorker";
+import type {
+  UnlockWorkerRequest,
+  UnlockWorkerResponse,
+} from "@/scripts/workers/unlockWorker";
+import {
+  kdfWorkerCount,
+  runWorkerJob,
+  splitIntoChunks,
+} from "@/scripts/workers/keystoreWorkerPool";
 import StorageUtil, { LockState } from "@/utilities/storageUtil";
-import { KeyStore, Web3BaseWalletAccount } from "@theqrl/web3";
+import { Web3BaseWalletAccount } from "@theqrl/web3";
 import { action, makeAutoObservable, runInAction } from "mobx";
 import browser from "webextension-polyfill";
 
@@ -170,30 +180,49 @@ class LockStore {
     const keyStores = await StorageUtil.getKeystores();
     if (!keyStores.length) return false;
 
-    const result = await new Promise<ChangePasswordWorkerResponse>(
-      (resolve) => {
-        const worker = new Worker(
-          new URL(
-            "../scripts/workers/changePasswordWorker.ts",
-            import.meta.url,
+    // Fan the keystores out over several workers so the argon2id runs
+    // execute concurrently (contiguous chunks keep the original order when
+    // the per-chunk results are concatenated back together).
+    const runChangeChunks = (chunks: (typeof keyStores)[]) =>
+      Promise.all(
+        chunks.map((chunk) =>
+          runWorkerJob<
+            ChangePasswordWorkerRequest,
+            ChangePasswordWorkerResponse
+          >(
+            () =>
+              new Worker(
+                new URL(
+                  "../scripts/workers/changePasswordWorker.ts",
+                  import.meta.url,
+                ),
+                { type: "module" },
+              ),
+            { keystores: chunk, oldPassword, newPassword },
+            { success: false, wrongPassword: false },
           ),
-          { type: "module" },
-        );
-        worker.onmessage = (
-          event: MessageEvent<ChangePasswordWorkerResponse>,
-        ) => {
-          worker.terminate();
-          resolve(event.data);
-        };
-        worker.onerror = () => {
-          worker.terminate();
-          resolve({ success: false });
-        };
-        worker.postMessage({ keystores: keyStores, oldPassword, newPassword });
-      },
-    );
+        ),
+      );
 
-    if (!result.success) return false;
+    let responses = await runChangeChunks(
+      splitIntoChunks(keyStores, kdfWorkerCount(keyStores.length)),
+    );
+    if (responses.some((r) => !r.success && r.wrongPassword)) return false;
+    if (responses.some((r) => !r.success)) {
+      // Infrastructure failure, not a wrong password: retry sequentially in
+      // one worker (peak memory of the old single-worker path).
+      responses = await runChangeChunks([keyStores]);
+    }
+
+    const succeeded = responses.filter(
+      (r): r is Extract<ChangePasswordWorkerResponse, { success: true }> =>
+        r.success,
+    );
+    if (succeeded.length !== responses.length) return false;
+    const result = {
+      newKeystores: succeeded.flatMap((r) => r.newKeystores),
+      newKeys: succeeded.flatMap((r) => r.newKeys),
+    };
 
     // Persist re-encrypted keystores.
     await StorageUtil.setKeystores(result.newKeystores);
@@ -301,62 +330,77 @@ class LockStore {
   }
 
   /**
-   * Unlock the wallet.  The CPU-heavy scrypt decryption runs in a dedicated
-   * Web Worker thread so the popup UI stays fully responsive (spinner animates).
+   * Unlock the wallet.  The CPU-heavy argon2id decryption runs in dedicated
+   * Web Worker threads (one per keystore chunk, capped by
+   * keystoreWorkerPool) so the popup UI stays fully responsive and multiple
+   * keystores decrypt concurrently.
    * After decryption the keys are sent to the SW for in-memory storage.
    *
    * Returns true on success, false on wrong password.
    * Throws on communication errors so the UI can show a distinct message.
    */
   async unlock(password: string): Promise<boolean> {
-    // Read keystores and decrypt in a Web Worker (separate thread).
+    // Read keystores and decrypt in Web Workers (separate threads).
     const keyStores = await StorageUtil.getKeystores();
     if (!keyStores.length) return false;
 
-    const workerResult = await new Promise<{
-      keys: DecryptedKeyType[];
-      upgradedKeystores?: KeyStore[];
-    } | null>((resolve) => {
-      const worker = new Worker(
-        new URL("../scripts/workers/unlockWorker.ts", import.meta.url),
-        { type: "module" },
+    // Contiguous chunks keep the original keystore order when the per-chunk
+    // results are concatenated back together.
+    const runUnlockChunks = (chunks: (typeof keyStores)[]) =>
+      Promise.all(
+        chunks.map((chunk) =>
+          runWorkerJob<UnlockWorkerRequest, UnlockWorkerResponse>(
+            () =>
+              new Worker(
+                new URL("../scripts/workers/unlockWorker.ts", import.meta.url),
+                { type: "module" },
+              ),
+            { keystores: chunk, password },
+            { success: false, wrongPassword: false },
+          ),
+        ),
       );
-      worker.onmessage = (
-        event: MessageEvent<{
-          success: boolean;
-          keys?: DecryptedKeyType[];
-          upgradedKeystores?: KeyStore[];
-        }>,
-      ) => {
-        worker.terminate();
-        if (event.data.success && event.data.keys) {
-          resolve({
-            keys: event.data.keys,
-            upgradedKeystores: event.data.upgradedKeystores,
-          });
-        } else {
-          resolve(null);
-        }
-      };
-      worker.onerror = () => {
-        worker.terminate();
-        resolve(null);
-      };
-      worker.postMessage({ keystores: keyStores, password });
-    });
 
-    if (!workerResult) {
-      // Wrong password or worker error
+    let responses = await runUnlockChunks(
+      splitIntoChunks(keyStores, kdfWorkerCount(keyStores.length)),
+    );
+    if (responses.some((r) => !r.success && r.wrongPassword)) {
       return false;
     }
-    const decryptedKeys = workerResult.keys;
+    if (responses.some((r) => !r.success)) {
+      // Infrastructure failure (e.g. concurrent WASM argon2id instances
+      // exhausted memory), NOT a wrong password. Retry everything in one
+      // sequential worker, whose peak memory matches the old single-worker
+      // path, before giving up.
+      responses = await runUnlockChunks([keyStores]);
+      const retry = responses[0];
+      if (retry && !retry.success) {
+        if (retry.wrongPassword) return false;
+        throw new Error(
+          "Unable to decrypt the wallet on this device right now. Close other tabs or apps to free memory and try again.",
+        );
+      }
+    }
 
-    // If the worker re-encrypted any keystores with stronger KDF parameters,
+    const succeeded = responses.filter(
+      (r): r is Extract<UnlockWorkerResponse, { success: true }> => r.success,
+    );
+    if (succeeded.length !== responses.length) {
+      return false;
+    }
+    const decryptedKeys: DecryptedKeyType[] = succeeded.flatMap((r) => r.keys);
+
+    // If a worker re-encrypted any keystores with stronger KDF parameters,
     // persist them in place of the previous keystores so the user benefits
-    // automatically without re-entering their password.
-    if (workerResult.upgradedKeystores?.length) {
+    // automatically without re-entering their password. The flattened
+    // upgraded list is index-aligned with keyStores.
+    const upgradedFlat = succeeded.flatMap((r) => r.upgraded);
+    if (upgradedFlat.some((k) => k !== null)) {
+      const mergedKeystores = keyStores.map(
+        (original, index) => upgradedFlat[index] ?? original,
+      );
       try {
-        await StorageUtil.setKeystores(workerResult.upgradedKeystores);
+        await StorageUtil.setKeystores(mergedKeystores);
       } catch (error) {
         console.warn(
           "QrlWeb3Wallet: failed to persist upgraded keystores",

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -4,13 +4,17 @@ import "@testing-library/jest-dom/vitest";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as Record<string, any>).IS_REACT_ACT_ENVIRONMENT = true;
 
-Object.defineProperty(window, "matchMedia", {
-  value: vi.fn().mockImplementation((query) => ({
-    matches: true,
-    query,
-  })),
-});
+// Guarded so test files that opt into the node environment (e.g. the
+// keystore crypto suite) can share this setup file without a jsdom window.
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "matchMedia", {
+    value: vi.fn().mockImplementation((query) => ({
+      matches: true,
+      query,
+    })),
+  });
 
-Object.defineProperty(window, "scrollTo", {
-  value: vi.fn().mockImplementation((x, y) => ({ x, y })),
-});
+  Object.defineProperty(window, "scrollTo", {
+    value: vi.fn().mockImplementation((x, y) => ({ x, y })),
+  });
+}


### PR DESCRIPTION
## Summary

The keystore KDF (`argon2id m=262144 t=8 p=1`) runs through the pure-JS implementation inside `@theqrl/web3-qrl-accounts`: roughly 20 s per keystore on desktop hardware, sequentially in a single worker, plus account create/import running it on the MV3 service-worker thread. Unlocking a multi-account wallet can take a minute or more.

This runs the same argon2id via `hash-wasm` (WebAssembly) and fans the per-keystore work out over a small worker pool.

**Result: unlock drops from ~20 s per account to ~2 s total for typical wallets.**

## What changed

- **`src/crypto/keystoreCrypto.ts`** (new): local `encryptKeystore` / `decryptKeystore`, byte-compatible with the `@theqrl/web3-qrl-accounts` format (same argon2id parameters, same AES-256-GCM envelope). The KDF runs via `hash-wasm` (~10x faster) with a pure-JS fallback (`@theqrl/qrl-cryptography`) when WebAssembly is unavailable. Cross-library vectors are pinned in `keystoreCrypto.test.ts`.
- **Worker fan-out**: `unlock` and `changePassword` split the keystores into contiguous chunks and run one worker per chunk, capped at 3 (each in-flight argon2id at the production parameters pins ~256 MiB). A wrong password (GCM `OperationError`) is distinguished from an infrastructure failure; on infra failure we retry sequentially in a single worker (peak memory of the old single-worker path) rather than blaming the password.
- **`lockManager.encryptAccount`** uses the WASM-backed path; the dead legacy `LockManager.unlock()` and its unused message constant are removed.
- **`manifest.json`**: the `extension_pages` CSP now includes `'wasm-unsafe-eval'` (the MV3 default CSP blocks WebAssembly instantiation).
- Adds `hash-wasm@4.12.0`.

## Byte compatibility

Keystores stay mutually compatible with `@theqrl/web3-qrl-accounts`. `keystoreCrypto.test.ts` verifies: round-trips our own keystores, decrypts keystores written by the upstream pure-JS implementation, upstream decrypts keystores we write, a byte-identical crypto envelope for fixed salt / iv / params, and that `hash-wasm` and the pure-JS argon2id stay byte-identical (dependency-drift guard).

## Validation

- `npm run lint`: clean
- `npm run build` (tsc + vite): passes
- `npm test`: passes (988 tests incl. the new byte-compat + fan-out suites)

## Notes

Independent of #26 (the `shouldUpgradeKeystoreParams` fix); the two touch disjoint files and can merge in either order. On its own this is a pure performance change: the KDF-params upgrade path behaves exactly as it does on `main` today (its gate is inert until #26 lands). Once both land, weak keystores are transparently re-encrypted via the fast WASM path on unlock.
